### PR TITLE
Fix XNB Loader's update check

### DIFF
--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -13,8 +13,8 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>

--- a/VersionChecker/XnbLoader.json
+++ b/VersionChecker/XnbLoader.json
@@ -1,5 +1,5 @@
 {
-    "Latest": "1.1.0",
+    "Latest": "1.1.1",
     "Minimum": "1.1.0",
     "Recommended": "1.1.0"
 }

--- a/XnbLoader/Mod.cs
+++ b/XnbLoader/Mod.cs
@@ -44,7 +44,7 @@ namespace Entoarox.XnbLoader
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            VersionChecker.AddCheck("XnbLoader", new Version(1, 0, 6), "https://raw.githubusercontent.com/Entoarox/StardewMods/master/VersionChecker/XnbLoader.json");
+            VersionChecker.AddCheck("XnbLoader", this.GetType().Assembly.GetName().Version, "https://raw.githubusercontent.com/Entoarox/StardewMods/master/VersionChecker/XnbLoader.json");
 
             // prepare directory structure
             string contentPath = Path.Combine(this.Helper.DirectoryPath, this.ContentFolderName);

--- a/XnbLoader/Properties/AssemblyInfo.cs
+++ b/XnbLoader/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/XnbLoader/manifest.json
+++ b/XnbLoader/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 1,
-    "PatchVersion": 0,
+    "PatchVersion": 1,
     "Build": null
   },
   "MinimumApiVersion": "1.15.2",


### PR DESCRIPTION
This pull request...

* Changes XNB Loader to use the assembly version (instead of a hardcoded version) for update checks, to fix an issue where players always get a critical-update-available message.
* Bumps the XNB Loader version for release.
* Fixes debugging in Entoarox Framework.

If these changes look fine, can you deploy [XnbLoader 1.1.1.zip](https://github.com/Entoarox/StardewMods/files/1250910/XnbLoader.1.1.1.zip) to the mod page?