### PR TITLE
Fix XNB Loader folder generation on Linux/Mac

### DIFF
--- a/XnbLoader/XnbLoaderMod.cs
+++ b/XnbLoader/XnbLoaderMod.cs
@@ -17,24 +17,24 @@ namespace Entoarox.XnbLoader
         /// <summary>The content paths to create when the mod starts.</summary>
         private readonly string[] PathsToCreate =
         {
-            @"Animals",
-            @"Buildings",
-            @"Characters\Dialogue",
-            @"Characters\Farmer",
-            @"Characters\Monsters",
-            @"Characters\schedules",
-            @"Data\Events",
-            @"Data\Festivals",
-            @"Data\TV",
-            @"Fonts",
-            @"LooseSprites\Lighting",
-            @"Maps",
-            @"Mines",
-            @"Minigames",
-            @"Portraits",
-            @"Strings",
-            @"TerrainFeatures",
-            @"TileSheets"
+            "Animals",
+            "Buildings",
+            Path.Combine("Characters", "Dialogue"),
+            Path.Combine("Characters", "Farmer"),
+            Path.Combine("Characters", "Monsters"),
+            Path.Combine("Characters", "schedules"),
+            Path.Combine("Data", "Events"),
+            Path.Combine("Data", "Festivals"),
+            Path.Combine("Data", "TV"),
+            "Fonts",
+            Path.Combine("LooseSprites", "Lighting"),
+            "Maps",
+            "Mines",
+            "Minigames",
+            "Portraits",
+            "Strings",
+            "TerrainFeatures",
+            "TileSheets"
         };
 
         private Dictionary<string, string> Cache = new Dictionary<string, string>();


### PR DESCRIPTION
XNB Loader generates a `ModContent` folder if one doesn't already exist. This pull request fixes that logic for compatibility with Linux/Mac.

(Note that this is a failsafe, and ideally the folders should be included in the release package to avoid confusion.)