### PR TITLE
Use balanced pet/skin allocation in More Animals

### DIFF
--- a/MoreAnimals/Framework/Chooser.cs
+++ b/MoreAnimals/Framework/Chooser.cs
@@ -13,13 +13,18 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         /// <summary>The underlying random number generator.</summary>
         public Random Random { get; private set; }
 
+        /// <summary>Whether to ensure an even distribution of values, if possible.</summary>
+        public bool BalanceDistribution { get; }
+
 
         /*********
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        public Chooser()
+        /// <param name="balanceDistribution">Whether to ensure an even distribution of values, if possible.</param>
+        public Chooser(bool balanceDistribution)
         {
+            this.BalanceDistribution = balanceDistribution;
             this.Random = new Random();
         }
 
@@ -45,10 +50,13 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         public T Choose<T>(T[] options, IDictionary<T, int> distribution)
         {
             // filter to least common values
-            int minCount = distribution.Values.Min();
-            options = options
-                .Where(opt => distribution.TryGetValue(opt, out int count) && count == minCount)
-                .ToArray();
+            if (this.BalanceDistribution)
+            {
+                int minCount = distribution.Values.Min();
+                options = options
+                    .Where(opt => distribution.TryGetValue(opt, out int count) && count == minCount)
+                    .ToArray();
+            }
 
             // choose
             return this.Choose(options);
@@ -60,6 +68,9 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         /// <param name="previous">The previous values.</param>
         public T Choose<T>(T[] options, Func<IEnumerable<T>> previous)
         {
+            if (!this.BalanceDistribution)
+                return this.Choose(options);
+
             // get distribution
             IDictionary<T, int> distribution = options.ToDictionary(p => p, p => 0);
             foreach (T value in previous())

--- a/MoreAnimals/Framework/Chooser.cs
+++ b/MoreAnimals/Framework/Chooser.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Entoarox.MorePetsAndAnimals.Framework
+{
+    /// <summary>Handles choosing from a set of available values.</summary>
+    internal class Chooser
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The underlying random number generator.</summary>
+        public Random Random { get; private set; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        public Chooser()
+        {
+            this.Random = new Random();
+        }
+
+        /// <summary>Reset the chooser.</summary>
+        /// <param name="seed">A number used to calculate a starting value for the pseudo-random number sequence.</param>
+        public void Reset(int seed)
+        {
+            this.Random = new Random(seed);
+        }
+
+        /// <summary>Randomly choose one of the available options.</summary>
+        /// <typeparam name="T">The option type.</typeparam>
+        /// <param name="options">The available options.</param>
+        public T Choose<T>(T[] options)
+        {
+            return options[this.Random.Next(options.Length)];
+        }
+
+        /// <summary>Randomly choose one of the available options.</summary>
+        /// <typeparam name="T">The option type.</typeparam>
+        /// <param name="options">The available options.</param>
+        /// <param name="distribution">The distribution of previous values.</param>
+        public T Choose<T>(T[] options, IDictionary<T, int> distribution)
+        {
+            // filter to least common values
+            int minCount = distribution.Values.Min();
+            options = options
+                .Where(opt => distribution.TryGetValue(opt, out int count) && count == minCount)
+                .ToArray();
+
+            // choose
+            return this.Choose(options);
+        }
+
+        /// <summary>Randomly choose one of the available options.</summary>
+        /// <typeparam name="T">The option type.</typeparam>
+        /// <param name="options">The available options.</param>
+        /// <param name="previous">The previous values.</param>
+        public T Choose<T>(T[] options, Func<IEnumerable<T>> previous)
+        {
+            // get distribution
+            IDictionary<T, int> distribution = options.ToDictionary(p => p, p => 0);
+            foreach (T value in previous())
+            {
+                if (distribution.ContainsKey(value))
+                    distribution[value]++;
+            }
+
+            // choose
+            return this.Choose(options, distribution);
+        }
+    }
+}

--- a/MoreAnimals/ModConfig.cs
+++ b/MoreAnimals/ModConfig.cs
@@ -36,5 +36,8 @@ namespace Entoarox.MorePetsAndAnimals
 
         /// <summary>True to disable the pet adoption box.</summary>
         public bool AnimalsOnly = false;
+
+        /// <summary>Whether to ensure an even distribution of skins and pet types, if possible.</summary>
+        public bool UseBalancedDistribution = false;
     }
 }

--- a/MoreAnimals/ModConfig.cs
+++ b/MoreAnimals/ModConfig.cs
@@ -8,7 +8,7 @@ namespace Entoarox.MorePetsAndAnimals
         ** Fields
         *********/
         private int _AdoptionPrice = 500;
-        private double _RepeatedAdoptionPenality = 0.1;
+        private double _RepeatedAdoptionPenalty = 0.1;
 
 
         /*********
@@ -22,10 +22,10 @@ namespace Entoarox.MorePetsAndAnimals
         }
 
         /// <summary>A penalty which reduces the chance of a pet in the adoption box based on the number of pets the player already has.</summary>
-        public double RepeatedAdoptionPenality
+        public double RepeatedAdoptionPenalty
         {
-            get => this._RepeatedAdoptionPenality;
-            set => this._RepeatedAdoptionPenality = Math.Max(0.0, Math.Min(0.9, value));
+            get => this._RepeatedAdoptionPenalty;
+            set => this._RepeatedAdoptionPenalty = Math.Max(0.0, Math.Min(0.9, value));
         }
 
         /// <summary>Whether to apply the <see cref="MaxAdoptionLimit"/> limit.</summary>

--- a/MoreAnimals/ModConfig.cs
+++ b/MoreAnimals/ModConfig.cs
@@ -14,20 +14,27 @@ namespace Entoarox.MorePetsAndAnimals
         /*********
         ** Accessors
         *********/
+        /// <summary>The price that must be paid to adopt a pet.</summary>
         public int AdoptionPrice
         {
             get => this._AdoptionPrice;
             set => this._AdoptionPrice = Math.Max(100, value);
         }
 
+        /// <summary>A penalty which reduces the chance of a pet in the adoption box based on the number of pets the player already has.</summary>
         public double RepeatedAdoptionPenality
         {
             get => this._RepeatedAdoptionPenality;
             set => this._RepeatedAdoptionPenality = Math.Max(0.0, Math.Min(0.9, value));
         }
 
+        /// <summary>Whether to apply the <see cref="MaxAdoptionLimit"/> limit.</summary>
         public bool UseMaxAdoptionLimit = false;
+
+        /// <summary>If <see cref="UseMaxAdoptionLimit"/> is true, the maximum number of pets the player can adopt (including the original pet).</summary>
         public int MaxAdoptionLimit = 10;
+
+        /// <summary>True to disable the pet adoption box.</summary>
         public bool AnimalsOnly = false;
     }
 }

--- a/MoreAnimals/ModEntry.cs
+++ b/MoreAnimals/ModEntry.cs
@@ -76,7 +76,7 @@ namespace Entoarox.MorePetsAndAnimals
                     "Statistics:\n"
                     + "  Config:\n"
                     + $"    AdoptionPrice: {ModEntry.Config.AdoptionPrice}\n"
-                    + $"    RepeatedAdoptionPenality: {ModEntry.Config.RepeatedAdoptionPenality}\n"
+                    + $"    RepeatedAdoptionPenalty: {ModEntry.Config.RepeatedAdoptionPenalty}\n"
                     + $"    UseMaxAdoptionLimit: {ModEntry.Config.UseMaxAdoptionLimit}\n"
                     + $"    MaxAdoptionLimit: {ModEntry.Config.MaxAdoptionLimit}\n"
                     + $"    AnimalsOnly: {ModEntry.Config.AnimalsOnly}\n"
@@ -404,7 +404,7 @@ namespace Entoarox.MorePetsAndAnimals
             int seed = Game1.year * 1000 + Array.IndexOf(ModEntry.Seasons, Game1.currentSeason) * 100 + Game1.dayOfMonth;
             this.Chooser.Reset(seed);
             List<Pet> list = this.GetAllPets().ToList();
-            if (ModEntry.Config.UseMaxAdoptionLimit && list.Count >= ModEntry.Config.MaxAdoptionLimit || this.Chooser.Random.NextDouble() < Math.Max(0.1, Math.Min(0.9, list.Count * ModEntry.Config.RepeatedAdoptionPenality)) || list.FindIndex(a => a.Age == seed) != -1)
+            if (ModEntry.Config.UseMaxAdoptionLimit && list.Count >= ModEntry.Config.MaxAdoptionLimit || this.Chooser.Random.NextDouble() < Math.Max(0.1, Math.Min(0.9, list.Count * ModEntry.Config.RepeatedAdoptionPenalty)) || list.FindIndex(a => a.Age == seed) != -1)
                 Game1.drawObjectDialogue("Just an empty box.");
             else
                 AdoptQuestion.Show(this.Helper.Events, this.GetAllPets().ToArray(), this.Chooser);

--- a/MoreAnimals/ModEntry.cs
+++ b/MoreAnimals/ModEntry.cs
@@ -341,7 +341,7 @@ namespace Entoarox.MorePetsAndAnimals
             if (ModEntry.Config.UseMaxAdoptionLimit && list.Count >= ModEntry.Config.MaxAdoptionLimit || ModEntry.Random.NextDouble() < Math.Max(0.1, Math.Min(0.9, list.Count * ModEntry.Config.RepeatedAdoptionPenality)) || list.FindIndex(a => a.Age == seed) != -1)
                 Game1.drawObjectDialogue("Just an empty box.");
             else
-                AdoptQuestion.Show(this.Helper.Events);
+                AdoptQuestion.Show(this.Helper.Events, this.GetAllPets().ToArray());
         }
     }
 }

--- a/MoreAnimals/ModEntry.cs
+++ b/MoreAnimals/ModEntry.cs
@@ -54,7 +54,7 @@ namespace Entoarox.MorePetsAndAnimals
             // init
             ModEntry.Config = helper.ReadConfig<ModConfig>();
             ModEntry.SHelper = helper;
-            this.Chooser = new Chooser();
+            this.Chooser = new Chooser(ModEntry.Config.UseBalancedDistribution);
 
             // add commands
             helper.ConsoleCommands.Add("abandon_pet", "Remove a pet with the given name.", this.OnCommandReceived);

--- a/MoreAnimals/MoreAnimals.csproj
+++ b/MoreAnimals/MoreAnimals.csproj
@@ -42,6 +42,7 @@
     <Compile Include="AdoptQuestion.cs" />
     <Compile Include="Framework\AnimalSkin.cs" />
     <Compile Include="Framework\AnimalType.cs" />
+    <Compile Include="Framework\Chooser.cs" />
     <Compile Include="ModConfig.cs" />
     <Compile Include="ModEntry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MoreAnimals/README.md
+++ b/MoreAnimals/README.md
@@ -58,6 +58,21 @@ assets/
       Rabbit_3.png
 ```
 
+## Configure
+The mod creates a `config.json` file in its mod folder the first time you run it. You can open that
+file in a text editor to configure the mod.
+
+These are the available settings:
+
+setting                    | what it affects
+-------------------------- | -------------------
+`AnimalsOnly`              | True to disable the pet adoption box. Default false.
+`AdoptionPrice`            | The gold you must pay to adopt a pet. Default 500, minimum 100.
+`MaxAdoptionLimit`         | If `UseMaxAdoptionLimit` is true, the maximum number of pets you can adopt (including the original pet). Default 10.
+`UseMaxAdoptionLimit`      | Whether to apply the `MaxAdoptionLimit` limit. Default false.
+`RepeatedAdoptionPenality` | A penalty which reduces the chance of a pet in the adoption box based on the number of pets you already have. (The default pet-in-box chance is 90%.) For example, `0.1` represents a 10% penalty per pet; after 5 pets, the chance is 90% - 50% or 40%. Note that this won't reduce the pet-in-box chance lower 10%. Default 0.1, must be 0–0.9 inclusive.
+`UseBalancedDistribution`  | Whether to try to assign an even distribution of skins and pet types, if possible. Default false.
+
 ## Compatibility
 * For Stardew Valley 1.3.30 or later.
 * Compatible with Linux, Mac, or Windows.


### PR DESCRIPTION
This PR changes More Animals to allocate pet types/skins in a balanced way. For example:
* If you have two cats and one dog, the next pet will be a dog.
* If you have one pet with skin A and none with skins B/C/D, the next pet will randomly use one of B/C/D.

~~Let me know if you want to make it configurable, or prefer to keep it entirely random. This doesn't currently apply to non-pet animals, but I can do the same there if you want.~~ Now configurable, and applies to farm animals too.

(Based on a user request sent via Nexus DMs.)