### PR TITLE
[More Animals] Support non-vanilla farm animal skins

### DIFF
--- a/MoreAnimals/AdoptQuestion.cs
+++ b/MoreAnimals/AdoptQuestion.cs
@@ -146,8 +146,8 @@ namespace Entoarox.MorePetsAndAnimals
         /// <param name="chooser">Handles choosing from a set of available values.</param>
         private static AnimalType GetNextPet(Pet[] currentPets, Chooser chooser)
         {
-            int catSkins = ModEntry.Skins[AnimalType.Cat].Length;
-            int dogSkins = ModEntry.Skins[AnimalType.Dog].Length;
+            int catSkins = ModEntry.Skins[AnimalType.Cat.ToString()].Length;
+            int dogSkins = ModEntry.Skins[AnimalType.Dog.ToString()].Length;
 
             // choose whichever has skins
             if (catSkins == 0 || dogSkins == 0)
@@ -167,7 +167,7 @@ namespace Entoarox.MorePetsAndAnimals
         private static int GetNextSkin(bool isCat, Pet[] currentPets, Chooser chooser)
         {
             // get available skins
-            AnimalSkin[] skins = ModEntry.Skins[isCat ? AnimalType.Cat : AnimalType.Dog];
+            AnimalSkin[] skins = ModEntry.Skins[isCat ? AnimalType.Cat.ToString() : AnimalType.Dog.ToString()];
             if (!skins.Any())
                 return 0;
 

--- a/MoreAnimals/Framework/AnimalSkin.cs
+++ b/MoreAnimals/Framework/AnimalSkin.cs
@@ -9,7 +9,7 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         ** Accessors
         *********/
         /// <summary>The animal type.</summary>
-        public AnimalType AnimalType { get; }
+        public string AnimalType { get; }
 
         /// <summary>A unique skin ID for the animal type.</summary>
         public int ID { get; }
@@ -25,7 +25,7 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         /// <param name="animalType">The animal type.</param>
         /// <param name="id">A unique skin ID for the animal type.</param>
         /// <param name="assetKey">The internal asset key.</param>
-        public AnimalSkin(AnimalType animalType, int id, string assetKey)
+        public AnimalSkin(string animalType, int id, string assetKey)
         {
             this.AnimalType = animalType;
             this.ID = id;
@@ -36,10 +36,9 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         /// <param name="raw">The raw animal type.</param>
         /// <param name="type">The parsed value, if valid.</param>
         /// <returns>Returns whether the value was successfully parsed.</returns>
-        public static bool TryParseType(string raw, out AnimalType type)
+        public static string ParseType(string raw)
         {
-            raw = raw?.Replace(" ", ""); // convert names like 'Brown Cow'
-            return Enum.TryParse(raw, true, out type);
+            return raw?.Replace(" ", ""); // convert names like 'Brown Cow'
         }
     }
 }

--- a/MoreAnimals/Framework/AnimalType.cs
+++ b/MoreAnimals/Framework/AnimalType.cs
@@ -6,31 +6,7 @@ namespace Entoarox.MorePetsAndAnimals.Framework
     [SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "The enum values are constructed dynamically.")]
     internal enum AnimalType
     {
-        BabyBlueChicken,
-        BabyBrownChicken,
-        BabyBrownCow,
-        BabyDuck, // Special: MorePets separates baby ducks from baby white chickens (BabyDuck.png as a copy of BabyWhite Chicken.png is bundled because of this)
-        BabyGoat,
-        BabyPig,
-        BabyRabbit,
-        BabySheep,
-        BabyVoidChicken,
-        BabyWhiteChicken,
-        BabyWhiteCow,
-        BlueChicken,
-        BrownChicken,
-        BrownCow,
         Cat,
-        Dinosaur,
-        Dog,
-        Duck,
-        Goat,
-        Pig,
-        Rabbit,
-        ShearedSheep,
-        Sheep,
-        VoidChicken,
-        WhiteChicken,
-        WhiteCow
+        Dog
     }
 }


### PR DESCRIPTION
- Use the farm animal types from  Data/FarmAnimals pulled on GameLaunched instead of the hardcoded ones to support mods that add new animals such as BFAV (https://www.nexusmods.com/stardewvalley/mods/3296). Still supports BabyDuck without the hardcoded value
- Changed AnimalSkin types to strings to support the dictionary keys. Pets are still hardcoded and should use ToString to continue support