### PR TITLE
[More Animals] Support non-vanilla farm animal skins

### DIFF
--- a/MoreAnimals/AdoptQuestion.cs
+++ b/MoreAnimals/AdoptQuestion.cs
@@ -40,8 +40,8 @@ namespace Entoarox.MorePetsAndAnimals
         {
             Random random = ModEntry.Random;
 
-            int catLimit = ModEntry.Indexes[AnimalType.Cat].Length;
-            int dogLimit = ModEntry.Indexes[AnimalType.Dog].Length;
+            int catLimit = ModEntry.Indexes[AnimalType.Cat.ToString()].Length;
+            int dogLimit = ModEntry.Indexes[AnimalType.Dog.ToString()].Length;
 
             bool cat = catLimit != 0 && (dogLimit == 0 || random.NextDouble() < 0.5);
             AdoptQuestion q = new AdoptQuestion(cat, random.Next(1, cat ? catLimit : dogLimit), events);

--- a/MoreAnimals/Framework/AnimalSkin.cs
+++ b/MoreAnimals/Framework/AnimalSkin.cs
@@ -9,7 +9,7 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         ** Accessors
         *********/
         /// <summary>The animal type.</summary>
-        public AnimalType AnimalType { get; }
+        public string AnimalType { get; }
 
         /// <summary>A unique skin ID for the animal type.</summary>
         public int ID { get; }
@@ -25,21 +25,19 @@ namespace Entoarox.MorePetsAndAnimals.Framework
         /// <param name="animalType">The animal type.</param>
         /// <param name="id">A unique skin ID for the animal type.</param>
         /// <param name="assetKey">The internal asset key.</param>
-        public AnimalSkin(AnimalType animalType, int id, string assetKey)
+        public AnimalSkin(string animalType, int id, string assetKey)
         {
             this.AnimalType = animalType;
             this.ID = id;
             this.AssetKey = assetKey;
         }
 
-        /// <summary>Try to parse a raw animal type (e.g. from a filename) into an <see cref="AnimalType"/> value.</summary>
+        /// <summary>Parse a raw animal type (e.g. from a filename).</summary>
         /// <param name="raw">The raw animal type.</param>
-        /// <param name="type">The parsed value, if valid.</param>
         /// <returns>Returns whether the value was successfully parsed.</returns>
-        public static bool TryParseType(string raw, out AnimalType type)
+        public static string ParseType(string raw)
         {
-            raw = raw?.Replace(" ", ""); // convert names like 'Brown Cow'
-            return Enum.TryParse(raw, true, out type);
+            return raw?.Replace(" ", ""); // convert names like 'Brown Cow'
         }
     }
 }


### PR DESCRIPTION
- Use the farm animal types from  Data/FarmAnimals instead of the hardcoded ones to support mods that add new animals such as BFAV. Still supports BabyDuck without the hardcoded value
- Changed AnimalSkin types to strings to support the dictionary keys. Pets are still hardcoded and should use ToString to continue support