### PR TITLE
Update for removal of ExitGameImmediately in SMAPI 3.0

### DIFF
--- a/Framework/IMonitorExtensions.cs
+++ b/Framework/IMonitorExtensions.cs
@@ -34,7 +34,11 @@ namespace Entoarox.Framework
         {
             if (error != null)
                 message += Environment.NewLine + error;
-            self.ExitGameImmediately(message);
+
+            self.Log(message, LogLevel.Error);
+            self.Log("Forcing game crash", LogLevel.Error);
+            void InfiniteRecursiveLoop() => InfiniteRecursiveLoop();
+            InfiniteRecursiveLoop();
         }
     }
 }


### PR DESCRIPTION
SMAPI 3.0 drops support for the `monitor.ExitGameImmediately` method. This pull request rewrites Entoarox Framework's equivalent extension to log the message and then force a game crash with an infinite recursive loop.